### PR TITLE
Fixed issue #15

### DIFF
--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -17,7 +17,7 @@
 
     {{ if .Site.Params.showlatest }}
     <h2 class="title is-2 top-pad">Latest Post</h2>
-        {{ range first 1 (where .Data.Pages.ByPublishDate "Section" "blog") }} 
+        {{ range first 1 (where .Data.Pages.ByPublishDate.Reverse "Section" "blog") }} 
         <div class="summary">{{ .Date.Format .Site.Params.dateform }}
             <h3 class="title is-3 strong-post-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
                 <div class="markdown">

--- a/layouts/partials/blogsection.html
+++ b/layouts/partials/blogsection.html
@@ -2,7 +2,7 @@
 
 {{ if .Site.Params.showlatest }}
 <h2 class="title is-2 has-text-centered">Latest Post</h2>
-    {{ range first 1 (where .Data.Pages.ByPublishDate "Section" "blog") }} 
+    {{ range first 1 (where .Data.Pages.ByPublishDate.Reverse "Section" "blog") }} 
     <div class="summary">{{ .Date.Format .Site.Params.dateform }}
         <h3 class="title is-3 latest-post-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
             <div class="markdown">


### PR DESCRIPTION
When you order pages by publish date, the order is ascending so ranging first 1 pages gives you first blog post instead of latest post.