### PR TITLE
highlight.js for themeStyle=dark

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -24,6 +24,7 @@ canonifyurls        = true                          # Turns relative urls into a
     description     = "Website Description"         # Max 160 characters show in search results
     faviconFile     = "img/fav.ico"
     highlightjs     = true                          # Syntax highlighting
+    hljsTheme       = true                          # Select highlight.js theme: https://highlightjs.org/static/demo/
     footerText      = ""                            # Text to show in footer (overrides default text)
     fadeIn          = true                          # Turn on/off the fade-in effect
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -35,7 +35,13 @@
 
 <!-- CSS -->
 {{ if .Site.Params.highlightjs }}
+{{ if .Site.Params.hljsTheme }}
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/{{ .Site.Params.hljsTheme }}.min.css">
+{{ else if eq .Site.Params.themeStyle "light" }}
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/default.min.css">
+{{ else }}
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/tomorrow-night.min.css">
+{{ end }}
     <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
     <script>hljs.initHighlightingOnLoad();</script>
 {{ end }}

--- a/layouts/partials/projects.html
+++ b/layouts/partials/projects.html
@@ -39,7 +39,7 @@
 <!-- End Projects container -->
 
 <!-- Projects modals -->
-{{ range sort .Pages }} {{ if eq .Section "projects" }}
+{{ range sort .Pages }} {{ if eq .Section "projects" }} {{ if not .Params.external_link }}
 <div class="modal" id="modal{{.Title | urlize}}">
     <div class="modal-background"></div>
     <div class="modal-card">
@@ -67,7 +67,7 @@
         $('#modal{{.Title | urlize}}').removeClass('is-active');
     });
 </script>
-{{ end }} {{ end }}
+{{ end }} {{ end }} {{ end }}
 
 
 <div class="container has-text-centered top-pad">


### PR DESCRIPTION
Default highlight.js theme has light background that is not that nice for dark theme. Probably, `tomorrow-night` is not the best option in visual terms, I've just picked random dark theme as it was better than `default`.

To make it possible I had to disable rule `.markdown code {background-color:#f4f1bb; color:#111}` in `dark-style.css` as it specifies really light background for code blocks in dark theme. I'm unsure that it's expected style, is it? It's rendered that way:
![code background 2018-01-28 20-45-36](https://user-images.githubusercontent.com/21046/35485931-9b2741fa-0477-11e8-9894-17d37e5cfaa6.png)
![hljs-theme 2018-01-28 20-49-36](https://user-images.githubusercontent.com/21046/35485930-9ae6f47e-0477-11e8-8bfa-4da905b95e4c.png)

