### PR TITLE
Allow custom css files

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -27,6 +27,7 @@ canonifyurls        = true                              # Turns relative urls in
     pygmentsCodeFences  = true
     footertext          = ""                            # Text to show in footer (overrides default text)
     fadein              = true                          # Turn on/off the fade-in effect
+    customCSS           = []                            # Include custom css files e.g. ["css/foo.css", "css/bar.css"]
 
     showblog            = true                          # Show Blog section on home page
     showprojects        = true                          # Show Projects section on home page

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -60,6 +60,11 @@ crossorigin="anonymous"></script>
 
 {{ end }}
 
+<!-- Custom css -->
+{{ range .Site.Params.customCSS -}}
+    <link rel="stylesheet" href="{{ . | absURL }}">
+{{- end }}
+
 <!-- Icon -->
 <link rel="shortcut icon"
 {{ if .Site.Params.faviconFile }}


### PR DESCRIPTION
This allows users to include there custom css files. I could see the point in just allowing one file, not multiple.
Credit goes to https://discourse.gohugo.io/t/how-to-override-css-classes-with-hugo/3033